### PR TITLE
Up

### DIFF
--- a/src/bots/config.php
+++ b/src/bots/config.php
@@ -37,5 +37,11 @@ $consumerSecret = $ini['consumerSecret'] ?? '';
 $cookie_key     = $ini['cookie_key'] ?? '';
 $decrypt_key    = $ini['decrypt_key'] ?? '';
 
+if (empty($consumerKey) || empty($consumerSecret)) {
+    header("HTTP/1.1 500 Internal Server Error");
+    echo 'Required configuration directives not found in ini file';
+    exit(0);
+}
+
 $cookie_key = Key::loadFromAsciiSafeString($cookie_key);
 $decrypt_key = Key::loadFromAsciiSafeString($decrypt_key);

--- a/src/bots/config.php
+++ b/src/bots/config.php
@@ -2,6 +2,13 @@
 //---
 include_once __DIR__ . '/../vendor_load.php';
 //---
+$gUserAgent = 'mdwiki MediaWiki OAuth Client/1.0';
+$oauthUrl = 'https://meta.wikimedia.org/w/index.php?title=Special:OAuth';
+
+// Make the api.php URL from the OAuth URL.
+$apiUrl = preg_replace('/index\.php.*/', 'api.php', $oauthUrl);
+$domain = $_SERVER['SERVER_NAME'] ?? 'localhost';
+
 use Defuse\Crypto\Key;
 //---
 $ROOT_PATH = getenv("HOME") ?: 'I:/mdwiki/mdwiki';
@@ -24,29 +31,11 @@ if (
     echo 'Required configuration directives not found in ini file';
     exit(0);
 }
-// $gUserAgent = $ini['agent'];
-$gUserAgent = 'mdwiki MediaWiki OAuth Client/1.0';
-// Load the user token (request or access) from the session
-//---
-// To get this demo working, you need to go to this wiki and register a new OAuth consumer.
-// Not that this URL must be of the long form with 'title=Special:OAuth', and not a clean URL.
-$oauthUrl = 'https://meta.wikimedia.org/w/index.php?title=Special:OAuth';
 
-// Make the api.php URL from the OAuth URL.
-$apiUrl = preg_replace('/index\.php.*/', 'api.php', $oauthUrl);
-
-// When you register, you will get a consumer key and secret. Put these here (and for real
-// applications, keep the secret secret! The key is public knowledge.).
 $consumerKey    = $ini['consumerKey'] ?? '';
 $consumerSecret = $ini['consumerSecret'] ?? '';
-
-$consumerKey_new    = $ini['consumerKey_new'] ?? '';
-$consumerSecrety_new = $ini['consumerSecrety_new'] ?? '';
-
-$domain = $_SERVER['SERVER_NAME'] ?? 'localhost';
-
 $cookie_key     = $ini['cookie_key'] ?? '';
-$cookie_key = Key::loadFromAsciiSafeString($cookie_key);
+$decrypt_key    = $ini['decrypt_key'] ?? '';
 
-$decrypt_key     = $ini['decrypt_key'] ?? '';
+$cookie_key = Key::loadFromAsciiSafeString($cookie_key);
 $decrypt_key = Key::loadFromAsciiSafeString($decrypt_key);

--- a/src/bots/config.php
+++ b/src/bots/config.php
@@ -2,7 +2,6 @@
 //---
 include_once __DIR__ . '/../vendor_load.php';
 //---
-$gUserAgent = 'mdwiki MediaWiki OAuth Client/1.0';
 $oauthUrl = 'https://meta.wikimedia.org/w/index.php?title=Special:OAuth';
 
 // Make the api.php URL from the OAuth URL.
@@ -10,42 +9,21 @@ $apiUrl = preg_replace('/index\.php.*/', 'api.php', $oauthUrl);
 $domain = $_SERVER['SERVER_NAME'] ?? 'localhost';
 
 use Defuse\Crypto\Key;
-//---
-$ROOT_PATH = getenv("HOME") ?: 'I:/mdwiki/mdwiki';
-//---
-$inifile = $ROOT_PATH . '/confs/OAuthConfig.ini';
-//---
-$ini = parse_ini_file($inifile);
-//---
-if ($ini === false) {
-    header("HTTP/1.1 500 Internal Server Error");
-    echo "The ini file:($inifile) could not be read";
-    exit(0);
-}
-if (
-    !isset($ini['agent']) ||
-    !isset($ini['consumerKey']) ||
-    !isset($ini['consumerSecret'])
-) {
+
+// ----------------
+// ----------------
+$CONSUMER_KEY        = getenv("CONSUMER_KEY") ?: '';
+$CONSUMER_SECRET     = getenv("CONSUMER_SECRET") ?: '';
+$_cookie_key_str     = getenv("COOKIE_KEY") ?: '';
+$_decrypt_key_str    = getenv("DECRYPT_KEY") ?: '';
+// ----------------
+// ----------------
+
+if (empty($CONSUMER_KEY) || empty($CONSUMER_SECRET)) {
     header("HTTP/1.1 500 Internal Server Error");
     echo 'Required configuration directives not found in ini file';
     exit(0);
 }
 
-// ----------------
-// ----------------
-$consumerKey        = $ini['consumerKey'] ?? '';
-$consumerSecret     = $ini['consumerSecret'] ?? '';
-$cookie_key_str     = $ini['cookie_key'] ?? '';
-$decrypt_key_str    = $ini['decrypt_key'] ?? '';
-// ----------------
-// ----------------
-
-if (empty($consumerKey) || empty($consumerSecret)) {
-    header("HTTP/1.1 500 Internal Server Error");
-    echo 'Required configuration directives not found in ini file';
-    exit(0);
-}
-
-$cookie_key  = Key::loadFromAsciiSafeString($cookie_key_str);
-$decrypt_key = Key::loadFromAsciiSafeString($decrypt_key_str);
+$cookie_key  = Key::loadFromAsciiSafeString($_cookie_key_str);
+$decrypt_key = Key::loadFromAsciiSafeString($_decrypt_key_str);

--- a/src/bots/config.php
+++ b/src/bots/config.php
@@ -32,10 +32,14 @@ if (
     exit(0);
 }
 
-$consumerKey    = $ini['consumerKey'] ?? '';
-$consumerSecret = $ini['consumerSecret'] ?? '';
-$cookie_key     = $ini['cookie_key'] ?? '';
-$decrypt_key    = $ini['decrypt_key'] ?? '';
+// ----------------
+// ----------------
+$consumerKey            = $ini['consumerKey'] ?? '';
+$consumerSecret         = $ini['consumerSecret'] ?? '';
+$cookie_key             = $ini['cookie_key'] ?? '';
+$decrypt_key            = $ini['decrypt_key'] ?? '';
+// ----------------
+// ----------------
 
 if (empty($consumerKey) || empty($consumerSecret)) {
     header("HTTP/1.1 500 Internal Server Error");

--- a/src/bots/config.php
+++ b/src/bots/config.php
@@ -34,10 +34,10 @@ if (
 
 // ----------------
 // ----------------
-$consumerKey            = $ini['consumerKey'] ?? '';
-$consumerSecret         = $ini['consumerSecret'] ?? '';
-$cookie_key             = $ini['cookie_key'] ?? '';
-$decrypt_key            = $ini['decrypt_key'] ?? '';
+$consumerKey        = $ini['consumerKey'] ?? '';
+$consumerSecret     = $ini['consumerSecret'] ?? '';
+$cookie_key_str     = $ini['cookie_key'] ?? '';
+$decrypt_key_str    = $ini['decrypt_key'] ?? '';
 // ----------------
 // ----------------
 
@@ -47,5 +47,5 @@ if (empty($consumerKey) || empty($consumerSecret)) {
     exit(0);
 }
 
-$cookie_key = Key::loadFromAsciiSafeString($cookie_key);
-$decrypt_key = Key::loadFromAsciiSafeString($decrypt_key);
+$cookie_key  = Key::loadFromAsciiSafeString($cookie_key_str);
+$decrypt_key = Key::loadFromAsciiSafeString($decrypt_key_str);

--- a/src/bots/cors.php
+++ b/src/bots/cors.php
@@ -8,11 +8,11 @@ use function Publish\CORS\is_allowed;
 
 */
 
-$domains = ['medwiki.toolforge.org', 'mdwikicx.toolforge.org'];
+
 
 function is_allowed()
 {
-    global $domains;
+    $domains = ['medwiki.toolforge.org', 'mdwikicx.toolforge.org'];
     // Check if the request is coming from allowed domains
     $referer = isset($_SERVER['HTTP_REFERER']) ? $_SERVER['HTTP_REFERER'] : '';
     $origin = isset($_SERVER['HTTP_ORIGIN']) ? $_SERVER['HTTP_ORIGIN'] : '';

--- a/src/bots/do_edit.php
+++ b/src/bots/do_edit.php
@@ -32,15 +32,17 @@ function get_edits_token($client, $accessToken, $apiUrl)
 
 function publish_do_edit($apiParams, $wiki, $access_key, $access_secret)
 {
-    global $gUserAgent, $consumerKey, $consumerSecret;
+    // ---
+    $CONSUMER_KEY        = getenv("CONSUMER_KEY") ?: '';
+    $CONSUMER_SECRET     = getenv("CONSUMER_SECRET") ?: '';
     // ---
     $oauthUrl = "https://$wiki.wikipedia.org/w/index.php?title=Special:OAuth";
     $apiUrl = "https://$wiki.wikipedia.org/w/api.php";
     // ---
     // Configure the OAuth client with the URL and consumer details.
     $conf = new ClientConfig($oauthUrl);
-    $conf->setConsumer(new Consumer($consumerKey, $consumerSecret));
-    $conf->setUserAgent($gUserAgent);
+    $conf->setConsumer(new Consumer($CONSUMER_KEY, $CONSUMER_SECRET));
+    $conf->setUserAgent('mdwiki MediaWiki OAuth Client/1.0');
     $client = new Client($conf);
     // ---
     $accessToken = new Token($access_key, $access_secret);

--- a/src/bots/get_token.php
+++ b/src/bots/get_token.php
@@ -18,7 +18,9 @@ use function Publish\Helps\pub_test_print;
 
 function get_client($wiki, $oauthUrl = "")
 {
-    global $gUserAgent, $consumerKey, $consumerSecret;
+    // ---
+    $CONSUMER_KEY        = getenv("CONSUMER_KEY") ?: '';
+    $CONSUMER_SECRET     = getenv("CONSUMER_SECRET") ?: '';
     // ---
     if (!empty($wiki)) {
         $oauthUrl = "https://$wiki.wikipedia.org/w/index.php?title=Special:OAuth";
@@ -26,8 +28,8 @@ function get_client($wiki, $oauthUrl = "")
     // ---
     // Configure the OAuth client with the URL and consumer details.
     $conf = new ClientConfig($oauthUrl);
-    $conf->setConsumer(new Consumer($consumerKey, $consumerSecret));
-    $conf->setUserAgent($gUserAgent);
+    $conf->setConsumer(new Consumer($CONSUMER_KEY, $CONSUMER_SECRET));
+    $conf->setUserAgent('mdwiki MediaWiki OAuth Client/1.0');
     $client = new Client($conf);
     // ---
     return $client;

--- a/src/bots/helps.php
+++ b/src/bots/helps.php
@@ -12,8 +12,6 @@ include_once __DIR__ . '/../include.php';
 
 use Defuse\Crypto\Crypto;
 
-$usr_agent = 'WikiProjectMed Translation Dashboard/1.0 (https://mdwiki.toolforge.org/; tools.mdwiki@toolforge.org)';
-
 function pub_test_print($s)
 {
     //---
@@ -65,7 +63,7 @@ function encode_value($value, $key_type = "cookie")
 
 function get_url_curl(string $url): string
 {
-    global $usr_agent;
+    $usr_agent = 'WikiProjectMed Translation Dashboard/1.0 (https://mdwiki.toolforge.org/; tools.mdwiki@toolforge.org)';
 
     $ch = curl_init($url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/src/bots/mdwiki_sql.php
+++ b/src/bots/mdwiki_sql.php
@@ -22,45 +22,35 @@ class Database
 
     private $db;
     private $host;
-    private $home_dir;
     private $user;
     private $password;
     private $dbname;
-    private $db_suffix;
     private $groupByModeDisabled = false;
 
-    public function __construct($server_name, $db_suffix = 'mdwiki')
+    public function __construct(string $dbname_var = 'DB_NAME')
     {
-        if (empty($db_suffix)) {
-            $db_suffix = 'mdwiki';
-        }
-        // ---
-        $this->home_dir = getenv("HOME") ?: 'I:/mdwiki/mdwiki';
-        //---
-        $this->db_suffix = $db_suffix;
-        $this->set_db($server_name);
+        $this->set_db($dbname_var);
     }
 
-    private function set_db($server_name)
+    private function envVar(string $key)
     {
-        // $ts_pw = posix_getpwuid(posix_getuid());
-        // $ts_mycnf = parse_ini_file($ts_pw['dir'] . "/confs/db.ini");
-        // ---
-        $ts_mycnf = parse_ini_file($this->home_dir . "/confs/db.ini");
-        // ---
-        if ($server_name === 'localhost') {
-            $this->host = 'localhost:3306';
-            $this->dbname = $ts_mycnf['user'] . "__" . $this->db_suffix;
-            $this->user = 'root';
-            $this->password = 'root11';
-        } else {
-            $this->host = 'tools.db.svc.wikimedia.cloud';
-            $this->dbname = $ts_mycnf['user'] . "__" . $this->db_suffix;
-            $this->user = $ts_mycnf['user'];
-            $this->password = $ts_mycnf['password'];
+        $value = getenv($key);
+        if ($value !== false) {
+            return $value;
         }
-        // unset($ts_mycnf, $ts_pw);
-        unset($ts_mycnf);
+
+        if (array_key_exists($key, $_ENV)) {
+            return $_ENV[$key];
+        }
+
+        return "";
+    }
+    private function set_db(string $dbname_var)
+    {
+        $this->host = $this->envVar('DB_HOST') ?: 'tools.db.svc.wikimedia.cloud';
+        $this->dbname = $this->envVar($dbname_var);
+        $this->user = $this->envVar('TOOL_TOOLSDB_USER');
+        $this->password = $this->envVar('TOOL_TOOLSDB_PASSWORD');
 
         try {
             $this->db = new PDO("mysql:host=$this->host;dbname=$this->dbname", $this->user, $this->password);
@@ -149,7 +139,7 @@ function get_dbname($table_name)
 {
     // Load from configuration file or define as class constant
     $table_db_mapping = [
-        'mdwiki_new' => [
+        'DB_NAME_NEW' => [
             "missing",
             "missing_by_qids",
             "exists_by_qids",
@@ -159,7 +149,7 @@ function get_dbname($table_name)
             "publish_reports_stats",
             "all_qids_titles"
         ],
-        'mdwiki' => [] // default
+        'DB_NAME' => [] // default
     ];
 
     if ($table_name) {
@@ -170,16 +160,16 @@ function get_dbname($table_name)
         }
     }
 
-    return 'mdwiki'; // default
+    return 'DB_NAME'; // default
 }
 
 function execute_query($sql_query, $params = null, $table_name = null)
 {
 
-    $dbname = get_dbname($table_name);
+    $dbname_var = get_dbname($table_name);
 
     // Create a new database object
-    $db = new Database($_SERVER['SERVER_NAME'] ?? '', $dbname);
+    $db = new Database($dbname_var);
 
     // Execute a SQL query
     if ($params) {
@@ -200,10 +190,10 @@ function execute_query($sql_query, $params = null, $table_name = null)
 function fetch_query(string $sql_query, ?array $params = null, $table_name = null): array
 {
 
-    $dbname = get_dbname($table_name);
+    $dbname_var = get_dbname($table_name);
 
     // Create a new database object
-    $db = new Database($_SERVER['SERVER_NAME'] ?? '', $dbname);
+    $db = new Database($dbname_var);
 
     // Execute a SQL query
     if ($params) {


### PR DESCRIPTION
This pull request refactors the configuration and database connection logic across several scripts to improve security and maintainability. The main changes are migrating sensitive configuration (such as OAuth credentials and encryption keys) from INI files to environment variables, standardizing the way database credentials and names are accessed, and simplifying code by removing unused or redundant variables.

Configuration and Credential Management:

* Migrated OAuth consumer keys, secrets, and encryption keys from an INI file to environment variables in `config.php`, with appropriate error handling if required variables are missing.
* Updated `do_edit.php` and `get_token.php` to use environment variables for OAuth credentials and set a consistent user agent string, removing reliance on global variables. [[1]](diffhunk://#diff-ab4d41c5be384914f89aa2ce6542190f3d9f05f42e307220da030ec30d7d38caL35-R45) [[2]](diffhunk://#diff-1d26191cc2b3fb03eb52979937ac47d2850372bc04f4acb956e60f4432a017caL21-R32)

Database Connection Refactoring:

* Refactored the `Database` class in `mdwiki_sql.php` to use environment variables for all connection parameters, replacing the previous logic that parsed INI files and constructed database names based on server name and user.
* Changed the table-to-database mapping and related functions to use environment variable names (e.g., `DB_NAME`, `DB_NAME_NEW`) instead of hardcoded names, and updated the logic for instantiating the `Database` class accordingly. [[1]](diffhunk://#diff-bb300edd680ca8d1293191014e24d2792664f153e23af176a753e96323e25057L152-R142) [[2]](diffhunk://#diff-bb300edd680ca8d1293191014e24d2792664f153e23af176a753e96323e25057L162-R152) [[3]](diffhunk://#diff-bb300edd680ca8d1293191014e24d2792664f153e23af176a753e96323e25057L173-R172) [[4]](diffhunk://#diff-bb300edd680ca8d1293191014e24d2792664f153e23af176a753e96323e25057L203-R196)

Code Cleanup and Consistency:

* Removed unused or redundant global variables and user agent assignments in `helps.php`, and ensured user agent strings are set locally where needed. [[1]](diffhunk://#diff-3441d6e9e654fa2f8cc3de1e9c4c61a37acd367968dd46adec07b40a57863f8fL15-L16) [[2]](diffhunk://#diff-3441d6e9e654fa2f8cc3de1e9c4c61a37acd367968dd46adec07b40a57863f8fL68-R66)
* Moved the allowed domains array inside the `is_allowed()` function in `cors.php` for better encapsulation.